### PR TITLE
Add MessageUpdated event call; 

### DIFF
--- a/vatACARS/Lib/Transceiver.cs
+++ b/vatACARS/Lib/Transceiver.cs
@@ -303,8 +303,8 @@ namespace vatACARS.Helpers
         {
             if (message is CPDLCMessage) CPDLCMessages.Remove((CPDLCMessage)message);
             if (message is TelexMessage) TelexMessages.Remove((TelexMessage)message);
+            MessageUpdated.Invoke(null, message);
         }
-
         public static class ClientInformation
         {
             public static string Callsign = "";


### PR DESCRIPTION
The `removeMessage` method in `Transceiver.cs` now includes a call to `MessageUpdated.Invoke(null, message);` to notify that a message has been updated after it is removed from `CPDLCMessages` or `TelexMessages`.