### PR TITLE
Update AppData version to 1.1.2

### DIFF
--- a/vatACARS/vatACARS.cs
+++ b/vatACARS/vatACARS.cs
@@ -21,7 +21,7 @@ namespace vatACARS
 {
     public static class AppData
     {
-        public static Version CurrentVersion { get; } = new Version(1, 1, 1);
+        public static Version CurrentVersion { get; } = new Version(1, 1, 2);
     }
 
     [Export(typeof(IPlugin))]


### PR DESCRIPTION
Updated the `CurrentVersion` property in the `AppData` class from `1.1.1` to `1.1.2`, indicating a minor update or patch to the application.