### PR TITLE
Dev

### DIFF
--- a/vatACARS/UI/Windows/PDCWindow.Designer.cs
+++ b/vatACARS/UI/Windows/PDCWindow.Designer.cs
@@ -1,16 +1,13 @@
-﻿namespace vatACARS.UI
+﻿using vatsys;
+using System.Windows.Forms;
+using VATSYSControls;
+
+namespace vatACARS.UI
 {
     partial class PDCWindow
     {
-        /// <summary>
-        /// Required designer variable.
-        /// </summary>
         private System.ComponentModel.IContainer components = null;
 
-        /// <summary>
-        /// Clean up any resources being used.
-        /// </summary>
-        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
         protected override void Dispose(bool disposing)
         {
             if (disposing && (components != null))
@@ -22,25 +19,76 @@
 
         #region Windows Form Designer generated code
 
-        /// <summary>
-        /// Required method for Designer support - do not modify
-        /// the contents of this method with the code editor.
-        /// </summary>
         private void InitializeComponent()
         {
+            this.strips_aircraft = new vatsys.ListViewEx();
+            this.vScrollBar1 = new VATSYSControls.ScrollBar();
+            this.label1 = new System.Windows.Forms.Label();
             this.SuspendLayout();
+            // 
+            // strips_aircraft
+            // 
+            this.strips_aircraft.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.strips_aircraft.BackColor = System.Drawing.SystemColors.ScrollBar;
+            this.strips_aircraft.HeaderStyle = System.Windows.Forms.ColumnHeaderStyle.Nonclickable;
+            this.strips_aircraft.HideSelection = false;
+            this.strips_aircraft.Location = new System.Drawing.Point(1, 2);
+            this.strips_aircraft.MultiSelect = false;
+            this.strips_aircraft.Name = "strips_aircraft";
+            this.strips_aircraft.Size = new System.Drawing.Size(464, 357);
+            this.strips_aircraft.TabIndex = 1;
+            this.strips_aircraft.UseCompatibleStateImageBehavior = false;
+            // 
+            // vScrollBar1
+            // 
+            this.vScrollBar1.ActualHeight = 10;
+            this.vScrollBar1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.vScrollBar1.Change = 1;
+            this.vScrollBar1.Location = new System.Drawing.Point(471, 2);
+            this.vScrollBar1.Name = "vScrollBar1";
+            this.vScrollBar1.Orientation = System.Windows.Forms.ScrollOrientation.VerticalScroll;
+            this.vScrollBar1.PercentageValue = 0F;
+            this.vScrollBar1.PreferredHeight = 10;
+            this.vScrollBar1.Size = new System.Drawing.Size(20, 357);
+            this.vScrollBar1.TabIndex = 2;
+            this.vScrollBar1.Value = 0;
+            // 
+            // label1
+            // 
+            this.label1.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.label1.AutoSize = true;
+            this.label1.Location = new System.Drawing.Point(12, 362);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(56, 17);
+            this.label1.TabIndex = 3;
+            this.label1.Text = "label1";
             // 
             // PDCWindow
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 17F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(396, 441);
+            this.ClientSize = new System.Drawing.Size(493, 388);
+            this.Controls.Add(this.label1);
+            this.Controls.Add(this.vScrollBar1);
+            this.Controls.Add(this.strips_aircraft);
+            this.MaximumSize = new System.Drawing.Size(497, 900);
+            this.MiddleClickClose = false;
+            this.MinimumSize = new System.Drawing.Size(497, 137);
             this.Name = "PDCWindow";
-            this.Text = "PDC";
+            this.Text = "Pre-Departure Clearance";
+            this.Resize += new System.EventHandler(this.PDCWindow_Resize);
             this.ResumeLayout(false);
+            this.PerformLayout();
 
         }
 
         #endregion
+
+        private vatsys.ListViewEx strips_aircraft;
+        private VATSYSControls.ScrollBar vScrollBar1;
+        private Label label1;
     }
 }

--- a/vatACARS/UI/Windows/PDCWindow.cs
+++ b/vatACARS/UI/Windows/PDCWindow.cs
@@ -1,11 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
 using System.Drawing;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows.Forms;
 using vatsys;
 
@@ -13,9 +8,147 @@ namespace vatACARS.UI
 {
     public partial class PDCWindow : BaseForm
     {
+        private List<Aircraft> aircraftList;
+
         public PDCWindow()
         {
             InitializeComponent();
+            StyleWindow();
+            this.Text = "Pre-Departure Clearance";
+            LoadSampleData();
+            InitializeListView();
+            LoadStrips();
+        }
+
+        private void LoadSampleData() // for testing
+        {
+            aircraftList = new List<Aircraft>
+            {
+                new Aircraft("QFA12", "B738", "YSSY", "NZAA", DateTime.Parse("21:29"), "Pending"),
+                new Aircraft("VOZ823", "A320", "YBBN", "YMML", DateTime.Parse("22:29"), "Pending"),
+                new Aircraft("JST401", "B789", "YSSY", "WSSS", DateTime.Parse("21:14"), "Pending"),
+                new Aircraft("UAL863", "B777", "YSSY", "KLAX", DateTime.Parse("23:29"), "Pending"),
+                new Aircraft("NZA118", "A321", "YSSY", "NZCH", DateTime.Parse("21:59"), "Pending")
+            };
+        }
+
+        private void InitializeListView()
+        {
+            // Basic ListView properties
+            strips_aircraft.View = View.Details;
+            strips_aircraft.FullRowSelect = true;
+            strips_aircraft.GridLines = true;
+            strips_aircraft.MultiSelect = false;
+            strips_aircraft.HeaderStyle = ColumnHeaderStyle.None;  // Remove built-in header
+            strips_aircraft.Font = new Font(MMI.eurofont_sml.FontFamily, 14F, FontStyle.Regular, GraphicsUnit.Pixel);
+
+            // Add columns with fixed widths (no headers)
+            strips_aircraft.Columns.Add("", 85);  // CALLSIGN
+            strips_aircraft.Columns.Add("", 65);  // TYPE
+            strips_aircraft.Columns.Add("", 110); // DEP/ARR
+            strips_aircraft.Columns.Add("", 60);  // ETD
+            strips_aircraft.Columns.Add("", 80);  // STATUS
+            strips_aircraft.Columns.Add("", 60);  // ACTION
+        }
+
+        private void LoadStrips()
+        {
+            strips_aircraft.Items.Clear();
+
+            // Add header as first row
+            ListViewItem headerItem = new ListViewItem(new[]
+            {
+                "CALLSIGN",
+                "TYPE",
+                "DEP/ARR",
+                "ETD",
+                "STATUS",
+                "ACTION"
+            });
+            headerItem.Font = new Font(MMI.eurofont_sml.FontFamily, 14F, FontStyle.Bold, GraphicsUnit.Pixel);
+            headerItem.UseItemStyleForSubItems = true;
+            strips_aircraft.Items.Add(headerItem);
+
+            // Add aircraft data
+            foreach (Aircraft aircraft in aircraftList)
+            {
+                ListViewItem item = new ListViewItem(new[]
+                {
+                    aircraft.Callsign,
+                    aircraft.Type,
+                    $"{aircraft.DepartureAirport}/{aircraft.ArrivalAirport}",
+                    aircraft.EstimatedDeparture.ToString("HHmm"),
+                    aircraft.Status,
+                    "SEND"
+                });
+
+                item.Tag = aircraft;
+                item.ForeColor = Color.White;
+                item.SubItems[1].ForeColor = Color.White;
+                item.SubItems[2].ForeColor = Color.White;
+                item.SubItems[3].ForeColor = Color.White;
+                item.SubItems[4].ForeColor = Color.White;
+
+                item.UseItemStyleForSubItems = false;
+
+                // Style the SEND button
+                item.SubItems[5].BackColor = Colours.GetColour(Colours.Identities.CPDLCSendButton);
+                item.SubItems[5].ForeColor = Color.White;
+
+                strips_aircraft.Items.Add(item);
+            }
+
+            strips_aircraft.MouseClick += Strips_aircraft_MouseClick;
+        }
+
+        private void Strips_aircraft_MouseClick(object sender, MouseEventArgs e)
+        {
+            ListViewHitTestInfo hit = strips_aircraft.HitTest(e.X, e.Y);
+            if (hit.Item != null && strips_aircraft.Items.IndexOf(hit.Item) > 0)  // Skip header row
+            {
+                ListViewItem.ListViewSubItem subItem = hit.SubItem;
+                if (subItem != null && hit.Item.SubItems.IndexOf(subItem) == 5)
+                {
+                    Aircraft aircraft = (Aircraft)hit.Item.Tag;
+                    HandleSendClick(aircraft);
+                }
+            }
+        }
+
+        private void HandleSendClick(Aircraft aircraft)
+        {
+            MessageBox.Show($"Sending PDC to {aircraft.Callsign}");
+        }
+
+        private void PDCWindow_Resize(object sender, EventArgs e)
+        {
+            label1.Text = $"Size: {this.Size.Width}x{this.Size.Height}";
+        }
+
+        private void StyleWindow()
+        {
+            this.BackColor = Colours.GetColour(Colours.Identities.WindowBackground);
+            strips_aircraft.BackColor = Colours.GetColour(Colours.Identities.WindowBackground);
+        }
+    }
+
+    public class Aircraft // Move to a type.cs file once finalized
+    {
+        public string Callsign { get; set; }
+        public string Type { get; set; }
+        public string DepartureAirport { get; set; }
+        public string ArrivalAirport { get; set; }
+        public DateTime EstimatedDeparture { get; set; }
+        public string Status { get; set; }
+
+        public Aircraft(string callsign, string type, string dep, string arr, DateTime etd, string status)
+        {
+            Callsign = callsign;
+            Type = type;
+            DepartureAirport = dep;
+            ArrivalAirport = arr;
+            EstimatedDeparture = etd;
+            Status = status;
         }
     }
 }

--- a/vatACARS/vatACARS.cs
+++ b/vatACARS/vatACARS.cs
@@ -284,31 +284,37 @@ namespace vatACARS
 
         private void Vatsys_ConnectionChanged(object sender, EventArgs e)
         {
-            if (!Network.IsConnected)
-            {
-                logger.Log("Disconnected");
-                MMI.InvokeOnGUI(() =>
+            try {
+                if (!Network.IsConnected)
                 {
-                    pdcWindowMenu.Item.Enabled = false;
-                    pdcWindow?.Close();
-                    dispatchWindowMenu.Item.Enabled = false;
-                    dispatchWindow?.Close();
-                });
-                return;
-            }
+                    logger.Log("Disconnected");
+                    MMI.InvokeOnGUI(() =>
+                    {
+                        pdcWindowMenu.Item.Enabled = false;
+                        pdcWindow?.Close();
+                        dispatchWindowMenu.Item.Enabled = false;
+                        dispatchWindow?.Close();
+                    });
+                    return;
+                }
 
-            var station = MMI.PrimePosition.ArrivalListAirports.FirstOrDefault();
-            logger.Log($"Connected to {station}");
+                var station = MMI.PrimePosition.ArrivalListAirports.FirstOrDefault();
+                logger.Log($"Connected to {station}");
 
-            if (station != null)
-            {
-                MMI.InvokeOnGUI(() =>
+                if (station != null)
                 {
-                    pdcWindowMenu.Item.Enabled = Network.Rating >= NetworkRating.S1;
-                    dispatchWindowMenu.Item.Enabled = Network.Rating >= NetworkRating.C1;
-                });
+                    MMI.InvokeOnGUI(() =>
+                    {
+                        pdcWindowMenu.Item.Enabled = Network.Rating >= NetworkRating.S1;
+                        dispatchWindowMenu.Item.Enabled = Network.Rating >= NetworkRating.C1;
+                    });
+                }
+            } catch (Exception ex)
+            {
+                logger.Log($"Error: {ex.Message}");
             }
         }
+
 
         public static class AppData
         {


### PR DESCRIPTION
This pull request includes updates to the `vatACARS` project to enhance the `PDCWindow` functionality, improve error handling, and add new UI components. Key changes include the introduction of a new `Aircraft` class, updates to the `PDCWindow` UI, and improved error logging.

### Enhancements to `PDCWindow`:

* [`vatACARS/UI/Windows/PDCWindow.Designer.cs`](diffhunk://#diff-eb36af825dbf217008405f40a1813ded7d3f1eef705db76ae28b9918f4eed3dcL1-L13): Added new UI components (`ListViewEx`, `ScrollBar`, and `Label`) and updated the window's properties, including resizing behavior and text. [[1]](diffhunk://#diff-eb36af825dbf217008405f40a1813ded7d3f1eef705db76ae28b9918f4eed3dcL1-L13) [[2]](diffhunk://#diff-eb36af825dbf217008405f40a1813ded7d3f1eef705db76ae28b9918f4eed3dcL25-R92)
* [`vatACARS/UI/Windows/PDCWindow.cs`](diffhunk://#diff-579f92ff5a0d087609fbdbe1a0c3d86aab23bc2450ba3e1d193b8f9cf0866a10L3-R151): Introduced a new `Aircraft` class, added methods for loading sample data, initializing the `ListView`, and handling click events on the `SEND` button. Added styling for the window and its components.

### Error Handling Improvement:

* [`vatACARS/vatACARS.cs`](diffhunk://#diff-b0e4833426f2a05359ad71fb105349f6aaf8bbbd12a11b9764db784c46d47b48R287): Wrapped the `Vatsys_ConnectionChanged` method in a try-catch block to log any exceptions that occur during the connection change event. [[1]](diffhunk://#diff-b0e4833426f2a05359ad71fb105349f6aaf8bbbd12a11b9764db784c46d47b48R287) [[2]](diffhunk://#diff-b0e4833426f2a05359ad71fb105349f6aaf8bbbd12a11b9764db784c46d47b48R312-R318)